### PR TITLE
Included fonts and images in package. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         # If any package contains .png or .ttf file,include them
         "binx-og-image-generator": ["fonts/*", "images/*"],
     },
-    include_package_data=True,
     zip_safe=False,
     platforms='any',
     install_requires=dependencies,


### PR DESCRIPTION
This makes sure that the folders specified in package data are included in the source distribution.

Reason: "If using the setuptools-specific include_package_data argument, files specified by package_data will not be automatically added to the manifest unless they are listed in the MANIFEST.in file." Source: https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files